### PR TITLE
Update slides with better visuals

### DIFF
--- a/app.js
+++ b/app.js
@@ -314,6 +314,7 @@ class PresentationController {
 
     initializeChunkingSlider() {
         const slider = document.getElementById('chunkSlider');
+        const message = document.getElementById('chunkMessage');
         if (!slider) return;
 
         slider.addEventListener('input', (e) => {
@@ -328,6 +329,11 @@ class PresentationController {
             targetChunks.forEach(chunk => {
                 chunk.style.display = 'inline-block';
             });
+
+            if (message) {
+                const labels = {1: 'Small chunks', 2: 'Medium chunks', 3: 'Large chunks'};
+                message.textContent = labels[value] || '';
+            }
         });
 
         // Initialize with medium chunks

--- a/index.html
+++ b/index.html
@@ -209,37 +209,21 @@
             <!-- Slide 6: Embedding Space -->
             <div class="slide" data-slide="6">
                 <div class="slide-content">
-                    <h1>Visualizing Embedding Space</h1>
+                    <h1>Embedding Space in 3D</h1>
                     <div class="embedding-space">
-                        <div class="space-container">
-                            <div class="cluster animals-cluster" data-delay="500">
-                                <div class="cluster-title">Animals</div>
-                                <div class="cluster-items">
-                                    <div class="concept-dot" data-hover="dog">🐕 dog</div>
-                                    <div class="concept-dot" data-hover="cat">🐱 cat</div>
-                                    <div class="concept-dot" data-hover="bird">🐦 bird</div>
-                                </div>
-                            </div>
-                            <div class="cluster royalty-cluster" data-delay="1000">
-                                <div class="cluster-title">Royalty</div>
-                                <div class="cluster-items">
-                                    <div class="concept-dot" data-hover="king">👑 king</div>
-                                    <div class="concept-dot" data-hover="queen">👸 queen</div>
-                                    <div class="concept-dot" data-hover="crown">👑 crown</div>
-                                </div>
-                            </div>
-                            <div class="cluster science-cluster" data-delay="1500">
-                                <div class="cluster-title">Science</div>
-                                <div class="cluster-items">
-                                    <div class="concept-dot" data-hover="experiment">🧪 experiment</div>
-                                    <div class="concept-dot" data-hover="research">🔬 research</div>
-                                    <div class="concept-dot" data-hover="data">📊 data</div>
-                                </div>
-                            </div>
+                        <div class="vector-3d">
+                            <div class="axis x-axis"></div>
+                            <div class="axis y-axis"></div>
+                            <div class="axis z-axis"></div>
+                            <div class="sentence-point" style="--x:40; --y:30; --z:-20;" data-delay="500">"Cats purr"</div>
+                            <div class="sentence-point" style="--x:60; --y:40; --z:10;" data-delay="700">"Dogs bark"</div>
+                            <div class="sentence-point" style="--x:-20; --y:50; --z:30;" data-delay="900">"Birds fly"</div>
+                            <div class="sentence-point" style="--x:20; --y:-30; --z:-40;" data-delay="1100">"Kings rule"</div>
+                            <div class="sentence-point" style="--x:-40; --y:-20; --z:50;" data-delay="1300">"Science experiments"</div>
                         </div>
-                        <div class="intuition-text" data-delay="2000">
+                        <div class="intuition-text" data-delay="1800">
                             <h3>Intuition:</h3>
-                            <p>Questions about pets will lie near "cat" and "dog" clusters</p>
+                            <p>Sentences with similar meaning appear close together in this 3D space</p>
                         </div>
                     </div>
                 </div>
@@ -343,6 +327,7 @@
                                 <span>Medium</span>
                                 <span>Large</span>
                             </div>
+                            <div id="chunkMessage" class="chunk-message">Medium chunks</div>
                         </div>
                         <div class="chunk-visualization">
                             <div class="document">
@@ -379,6 +364,7 @@
             <div class="slide" data-slide="10">
                 <div class="slide-content">
                     <h1>Recap — How Semantic Search Works</h1>
+                    <h2 class="subheading">Key Steps</h2>
                     <div class="recap-flow">
                         <div class="flow-step" data-delay="500">
                             <div class="step-icon">🗄️</div>
@@ -411,6 +397,7 @@
                                 <span>A similarity-based retrieval process using vector distance</span>
                             </div>
                         </div>
+                        <p class="recap-note" data-delay="4400">This pipeline runs each time you ask a question.</p>
                     </div>
                 </div>
             </div>
@@ -628,18 +615,27 @@
                     <div class="final-thoughts">
                         <div class="key-message" data-delay="500">
                             <h2>🎯 Key Takeaways</h2>
-                            <div class="bullet-points">
-                                <div class="bullet-item" data-delay="1000">
-                                    <span class="bullet">•</span>
-                                    <span><strong>Why traditional LLMs need RAG</strong> for private/custom knowledge</span>
+                            <div class="bullet-points grouped">
+                                <div class="bullet-group" data-delay="1000">
+                                    <h3 class="rag-section-title">Retrieval</h3>
+                                    <div class="bullet-item">
+                                        <span class="bullet">•</span>
+                                        <span>Find the most relevant chunks using vector search</span>
+                                    </div>
                                 </div>
-                                <div class="bullet-item" data-delay="1300">
-                                    <span class="bullet">•</span>
-                                    <span><strong>Embeddings power semantic search</strong> by capturing meaning</span>
+                                <div class="bullet-group" data-delay="1400">
+                                    <h3 class="rag-section-title">Augmentation</h3>
+                                    <div class="bullet-item">
+                                        <span class="bullet">•</span>
+                                        <span>Add those chunks to your prompt as context</span>
+                                    </div>
                                 </div>
-                                <div class="bullet-item" data-delay="1600">
-                                    <span class="bullet">•</span>
-                                    <span><strong>Vector DB + Chunking + Re-ranking</strong> make it scalable</span>
+                                <div class="bullet-group" data-delay="1800">
+                                    <h3 class="rag-section-title">Generation</h3>
+                                    <div class="bullet-item">
+                                        <span class="bullet">•</span>
+                                        <span>The LLM produces the final answer</span>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/style.css
+++ b/style.css
@@ -1443,28 +1443,27 @@ h3 {
   animation: drawLine 0.5s ease-out forwards;
 }
 
-.line1 {
+.line1,
+.line2,
+.line3 {
   top: 50%;
-  left: 50%;
-  width: 150px;
-  transform: rotate(30deg);
+  left: 20%;
   transform-origin: left center;
+}
+
+.line1 {
+  width: 300px;
+  transform: rotate(-25deg);
 }
 
 .line2 {
-  top: 50%;
-  left: 50%;
-  width: 120px;
-  transform: rotate(-20deg);
-  transform-origin: left center;
+  width: 320px;
+  transform: rotate(10deg);
 }
 
 .line3 {
-  top: 50%;
-  left: 50%;
-  width: 100px;
-  transform: rotate(60deg);
-  transform-origin: left center;
+  width: 280px;
+  transform: rotate(40deg);
 }
 
 @keyframes drawLine {
@@ -1500,17 +1499,17 @@ h3 {
 
 .doc1 {
   top: 20%;
-  right: 30%;
+  left: 70%;
 }
 
 .doc2 {
   bottom: 30%;
-  right: 20%;
+  left: 75%;
 }
 
 .doc3 {
   bottom: 20%;
-  left: 60%;
+  left: 55%;
 }
 
 @keyframes docAppear {
@@ -1642,6 +1641,90 @@ h3 {
   color: var(--color-text-secondary);
 }
 
+.chunk-message {
+  font-size: var(--font-size-sm);
+  color: var(--color-primary);
+  text-align: center;
+}
+
+.subheading {
+  font-size: var(--font-size-xl);
+  color: var(--color-primary);
+  margin-top: var(--space-16);
+  text-align: center;
+}
+
+.recap-note {
+  margin-top: var(--space-16);
+  text-align: center;
+  color: var(--color-text-secondary);
+}
+
+.bullet-group {
+  margin-bottom: var(--space-16);
+}
+
+.rag-section-title {
+  color: var(--color-primary);
+  font-size: var(--font-size-lg);
+  margin-bottom: var(--space-8);
+}
+
+/* 3D Vector Space */
+.vector-3d {
+  position: relative;
+  width: 350px;
+  height: 350px;
+  margin: 0 auto;
+  transform-style: preserve-3d;
+  perspective: 600px;
+}
+
+.axis {
+  position: absolute;
+  background: var(--color-border);
+}
+
+.x-axis {
+  height: 2px;
+  width: 250px;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.y-axis {
+  width: 2px;
+  height: 250px;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.z-axis {
+  height: 2px;
+  width: 250px;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%) rotateY(90deg);
+  transform-origin: left top;
+}
+
+.sentence-point {
+  position: absolute;
+  background: var(--color-primary);
+  color: var(--color-btn-primary-text);
+  padding: var(--space-4) var(--space-8);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-sm);
+  transform-style: preserve-3d;
+  opacity: 0;
+  animation: docAppear 0.3s ease-out forwards;
+  left: calc(50% + var(--x)px);
+  bottom: calc(40px + var(--y)px);
+  transform: translateZ(var(--z)px);
+}
+
 .chunk-visualization {
   display: flex;
   justify-content: center;
@@ -1742,7 +1825,8 @@ h3 {
   flex-direction: column;
   align-items: center;
   gap: var(--space-24);
-  margin: var(--space-32) 0;
+  margin: var(--space-32) auto;
+  max-width: 600px;
 }
 
 .hyde-step {
@@ -1750,6 +1834,7 @@ h3 {
   padding: var(--space-24);
   border-radius: var(--radius-lg);
   border: 1px solid var(--color-border);
+  width: 100%;
   max-width: 500px;
   text-align: center;
   opacity: 0;


### PR DESCRIPTION
## Summary
- redesign embedding space to show sentences in 3‑D
- correct search arrows and document positions
- add interactive chunk size message
- improve recap slide with subheading and note
- limit HyDE slide width
- group wrap‑up steps into retrieval/augmentation/generation

## Testing
- `python3 rag_demo.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68549f7feae883318fbfa8248737177e