### PR TITLE
Improve visual content for slides 6-15

### DIFF
--- a/app.js
+++ b/app.js
@@ -316,10 +316,13 @@ class PresentationController {
         const slider = document.getElementById('chunkSlider');
         if (!slider) return;
 
+        const display = document.querySelector('.chunk-size-display');
+        const labels = { '1': 'Small', '2': 'Medium', '3': 'Large' };
+
         slider.addEventListener('input', (e) => {
             const value = e.target.value;
             const chunks = document.querySelectorAll('.chunk');
-            
+
             chunks.forEach(chunk => {
                 chunk.style.display = 'none';
             });
@@ -328,6 +331,10 @@ class PresentationController {
             targetChunks.forEach(chunk => {
                 chunk.style.display = 'inline-block';
             });
+
+            if (display) {
+                display.textContent = `${labels[value]} chunks`;
+            }
         });
 
         // Initialize with medium chunks

--- a/index.html
+++ b/index.html
@@ -209,37 +209,19 @@
             <!-- Slide 6: Embedding Space -->
             <div class="slide" data-slide="6">
                 <div class="slide-content">
-                    <h1>Visualizing Embedding Space</h1>
-                    <div class="embedding-space">
-                        <div class="space-container">
-                            <div class="cluster animals-cluster" data-delay="500">
-                                <div class="cluster-title">Animals</div>
-                                <div class="cluster-items">
-                                    <div class="concept-dot" data-hover="dog">🐕 dog</div>
-                                    <div class="concept-dot" data-hover="cat">🐱 cat</div>
-                                    <div class="concept-dot" data-hover="bird">🐦 bird</div>
-                                </div>
-                            </div>
-                            <div class="cluster royalty-cluster" data-delay="1000">
-                                <div class="cluster-title">Royalty</div>
-                                <div class="cluster-items">
-                                    <div class="concept-dot" data-hover="king">👑 king</div>
-                                    <div class="concept-dot" data-hover="queen">👸 queen</div>
-                                    <div class="concept-dot" data-hover="crown">👑 crown</div>
-                                </div>
-                            </div>
-                            <div class="cluster science-cluster" data-delay="1500">
-                                <div class="cluster-title">Science</div>
-                                <div class="cluster-items">
-                                    <div class="concept-dot" data-hover="experiment">🧪 experiment</div>
-                                    <div class="concept-dot" data-hover="research">🔬 research</div>
-                                    <div class="concept-dot" data-hover="data">📊 data</div>
-                                </div>
-                            </div>
+                    <h1>Embedding Space as 3D Vectors</h1>
+                    <div class="vector3d-demo">
+                        <div class="vector-space-3d">
+                            <div class="axis x-axis"></div>
+                            <div class="axis y-axis"></div>
+                            <div class="axis z-axis"></div>
+                            <div class="vector-point" style="--x:40; --y:60; --z:20;" data-delay="500">"I love pizza"</div>
+                            <div class="vector-point" style="--x:70; --y:40; --z:50;" data-delay="700">"Dogs are great pets"</div>
+                            <div class="vector-point" style="--x:20; --y:80; --z:70;" data-delay="900">"Quantum physics is fascinating"</div>
                         </div>
-                        <div class="intuition-text" data-delay="2000">
-                            <h3>Intuition:</h3>
-                            <p>Questions about pets will lie near "cat" and "dog" clusters</p>
+                        <div class="vector-note" data-delay="1500">
+                            <h3>Sentence vectors</h3>
+                            <p>Similar sentences end up near each other in space.</p>
                         </div>
                     </div>
                 </div>
@@ -343,6 +325,7 @@
                                 <span>Medium</span>
                                 <span>Large</span>
                             </div>
+                            <div class="chunk-size-display" data-delay="700">Medium chunks</div>
                         </div>
                         <div class="chunk-visualization">
                             <div class="document">
@@ -379,6 +362,7 @@
             <div class="slide" data-slide="10">
                 <div class="slide-content">
                     <h1>Recap — How Semantic Search Works</h1>
+                    <div class="recap-callout" data-delay="300">Embed → Search → Retrieve</div>
                     <div class="recap-flow">
                         <div class="flow-step" data-delay="500">
                             <div class="step-icon">🗄️</div>
@@ -650,6 +634,20 @@
                                 <div class="rag-word augment">AUGMENT</div>
                                 <div class="rag-arrow">→</div>
                                 <div class="rag-word generate">GENERATE</div>
+                            </div>
+                        </div>
+                        <div class="rag-groups" data-delay="2500">
+                            <div class="rag-group">
+                                <h4>Retrieval</h4>
+                                <p>Search and rank documents</p>
+                            </div>
+                            <div class="rag-group">
+                                <h4>Augmentation</h4>
+                                <p>Add top chunks to your query</p>
+                            </div>
+                            <div class="rag-group">
+                                <h4>Generation</h4>
+                                <p>LLM produces the final answer</p>
                             </div>
                         </div>
                         <div class="questions-section" data-delay="3000">

--- a/style.css
+++ b/style.css
@@ -1288,6 +1288,76 @@ h3 {
   margin-top: var(--space-32);
 }
 
+/* 3D Vector Demo */
+.vector3d-demo {
+  margin-top: var(--space-32);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-24);
+}
+
+.vector-space-3d {
+  position: relative;
+  width: 400px;
+  height: 300px;
+  perspective: 800px;
+  transform-style: preserve-3d;
+  background: linear-gradient(135deg, #f0f9ff, #e0f2fe);
+  border-radius: var(--radius-lg);
+}
+
+.axis {
+  position: absolute;
+  background: var(--color-border);
+}
+
+.x-axis {
+  width: 180px;
+  height: 2px;
+  top: 80%;
+  left: 10%;
+}
+
+.y-axis {
+  width: 2px;
+  height: 180px;
+  top: 10%;
+  left: 10%;
+}
+
+.z-axis {
+  width: 2px;
+  height: 180px;
+  top: 80%;
+  left: 10%;
+  transform: rotateY(90deg);
+  transform-origin: top left;
+}
+
+.vector-point {
+  position: absolute;
+  background: var(--color-primary);
+  color: var(--color-btn-primary-text);
+  padding: var(--space-4) var(--space-8);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-sm);
+  transform: translate3d(calc(var(--x) * 1px), calc(-1 * var(--y) * 1px), calc(var(--z) * 1px));
+  opacity: 0;
+  animation: pointAppear 0.8s ease-out forwards;
+}
+
+@keyframes pointAppear {
+  from { opacity: 0; transform: translate3d(0, 0, 0); }
+  to { opacity: 1; transform: translate3d(calc(var(--x) * 1px), calc(-1 * var(--y) * 1px), calc(var(--z) * 1px)); }
+}
+
+.vector-note {
+  text-align: center;
+  opacity: 0;
+  animation: fadeIn 0.6s ease-out forwards;
+}
+
 .space-container {
   background: linear-gradient(135deg, #f0f9ff, #e0f2fe, #fef3e2);
   border-radius: var(--radius-lg);
@@ -1445,25 +1515,25 @@ h3 {
 
 .line1 {
   top: 50%;
-  left: 50%;
+  left: 20%;
   width: 150px;
-  transform: rotate(30deg);
+  transform: rotate(-30deg);
   transform-origin: left center;
 }
 
 .line2 {
   top: 50%;
-  left: 50%;
+  left: 20%;
   width: 120px;
-  transform: rotate(-20deg);
+  transform: rotate(15deg);
   transform-origin: left center;
 }
 
 .line3 {
   top: 50%;
-  left: 50%;
-  width: 100px;
-  transform: rotate(60deg);
+  left: 20%;
+  width: 110px;
+  transform: rotate(35deg);
   transform-origin: left center;
 }
 
@@ -1642,6 +1712,12 @@ h3 {
   color: var(--color-text-secondary);
 }
 
+.chunk-size-display {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-primary);
+}
+
 .chunk-visualization {
   display: flex;
   justify-content: center;
@@ -1690,6 +1766,15 @@ h3 {
   align-items: center;
   gap: var(--space-24);
   margin: var(--space-32) 0;
+}
+
+.recap-callout {
+  font-style: italic;
+  color: var(--color-primary);
+  margin-bottom: var(--space-16);
+  text-align: center;
+  opacity: 0;
+  animation: fadeIn 0.6s ease-out forwards;
 }
 
 .flow-step {
@@ -1750,7 +1835,9 @@ h3 {
   padding: var(--space-24);
   border-radius: var(--radius-lg);
   border: 1px solid var(--color-border);
-  max-width: 500px;
+  max-width: 420px;
+  width: 100%;
+  margin: 0 auto;
   text-align: center;
   opacity: 0;
   transform: translateY(20px);
@@ -2105,6 +2192,26 @@ h3 {
   display: flex;
   align-items: center;
   gap: var(--space-20);
+}
+
+.rag-groups {
+  display: flex;
+  justify-content: center;
+  gap: var(--space-24);
+  margin-top: var(--space-24);
+  flex-wrap: wrap;
+  text-align: center;
+}
+
+.rag-group {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-16) var(--space-24);
+  min-width: 140px;
+  opacity: 0;
+  transform: translateY(20px);
+  animation: fadeIn 0.6s ease-out forwards;
 }
 
 .rag-word {


### PR DESCRIPTION
## Summary
- redesign slide 6 using a simple 3‑D vector space with sentences
- tweak slide 7 search arrows so they point from the query
- add dynamic chunk size label on slide 9
- add callout to recap slide
- tighten HyDE step layout to fit on page
- group retrieval, augmentation and generation steps on the final slide
- include new styles and JS for these features

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68549f7feae883318fbfa8248737177e