### PR TITLE
Enhance vector slides

### DIFF
--- a/app.js
+++ b/app.js
@@ -319,6 +319,12 @@ class PresentationController {
         slider.addEventListener('input', (e) => {
             const value = e.target.value;
             const chunks = document.querySelectorAll('.chunk');
+
+            const feedback = document.getElementById('chunkFeedback');
+            if (feedback) {
+                const labels = ['Small', 'Medium', 'Large'];
+                feedback.textContent = labels[value - 1];
+            }
             
             chunks.forEach(chunk => {
                 chunk.style.display = 'none';

--- a/index.html
+++ b/index.html
@@ -211,35 +211,28 @@
                 <div class="slide-content">
                     <h1>Visualizing Embedding Space</h1>
                     <div class="embedding-space">
-                        <div class="space-container">
-                            <div class="cluster animals-cluster" data-delay="500">
-                                <div class="cluster-title">Animals</div>
-                                <div class="cluster-items">
-                                    <div class="concept-dot" data-hover="dog">🐕 dog</div>
-                                    <div class="concept-dot" data-hover="cat">🐱 cat</div>
-                                    <div class="concept-dot" data-hover="bird">🐦 bird</div>
-                                </div>
-                            </div>
-                            <div class="cluster royalty-cluster" data-delay="1000">
-                                <div class="cluster-title">Royalty</div>
-                                <div class="cluster-items">
-                                    <div class="concept-dot" data-hover="king">👑 king</div>
-                                    <div class="concept-dot" data-hover="queen">👸 queen</div>
-                                    <div class="concept-dot" data-hover="crown">👑 crown</div>
-                                </div>
-                            </div>
-                            <div class="cluster science-cluster" data-delay="1500">
-                                <div class="cluster-title">Science</div>
-                                <div class="cluster-items">
-                                    <div class="concept-dot" data-hover="experiment">🧪 experiment</div>
-                                    <div class="concept-dot" data-hover="research">🔬 research</div>
-                                    <div class="concept-dot" data-hover="data">📊 data</div>
-                                </div>
-                            </div>
+                        <div class="space-container vector-demo">
+                            <svg class="vector-plot" viewBox="0 0 400 350">
+                                <line x1="200" y1="250" x2="350" y2="250" class="axis x-axis" />
+                                <line x1="200" y1="250" x2="200" y2="70" class="axis y-axis" />
+                                <line x1="200" y1="250" x2="80" y2="320" class="axis z-axis" />
+
+                                <line x1="200" y1="250" x2="280" y2="170" class="vector-line" />
+                                <circle cx="280" cy="170" r="4" class="vector-point" />
+                                <text x="290" y="170" class="vector-label">"Cats chase mice" [0.3,0.7,0.2]</text>
+
+                                <line x1="200" y1="250" x2="260" y2="280" class="vector-line" />
+                                <circle cx="260" cy="280" r="4" class="vector-point" />
+                                <text x="270" y="282" class="vector-label">"The king wears a crown" [0.5,0.4,-0.1]</text>
+
+                                <line x1="200" y1="250" x2="140" y2="200" class="vector-line" />
+                                <circle cx="140" cy="200" r="4" class="vector-point" />
+                                <text x="150" y="200" class="vector-label">"Research uses data" [0.1,0.6,0.8]</text>
+                            </svg>
                         </div>
                         <div class="intuition-text" data-delay="2000">
                             <h3>Intuition:</h3>
-                            <p>Questions about pets will lie near "cat" and "dog" clusters</p>
+                            <p>Each sentence becomes a vector in 3‑D space.</p>
                         </div>
                     </div>
                 </div>
@@ -343,6 +336,7 @@
                                 <span>Medium</span>
                                 <span>Large</span>
                             </div>
+                            <div id="chunkFeedback" class="chunk-feedback">Medium</div>
                         </div>
                         <div class="chunk-visualization">
                             <div class="document">
@@ -382,16 +376,19 @@
                     <div class="recap-flow">
                         <div class="flow-step" data-delay="500">
                             <div class="step-icon">🗄️</div>
+                            <div class="step-title">1. Docs → Vectors</div>
                             <div class="step-text">Document store with precomputed embeddings</div>
                         </div>
                         <div class="flow-arrow" data-delay="1000">↓</div>
                         <div class="flow-step" data-delay="1500">
                             <div class="step-icon">❓</div>
+                            <div class="step-title">2. Embed Query</div>
                             <div class="step-text">Query converted to an embedding</div>
                         </div>
                         <div class="flow-arrow" data-delay="2000">↓</div>
                         <div class="flow-step" data-delay="2500">
                             <div class="step-icon">🔍</div>
+                            <div class="step-title">3. Retrieve Nearest</div>
                             <div class="step-text">Similarity-based retrieval using vector distance (cosine similarity)</div>
                         </div>
                     </div>
@@ -650,6 +647,21 @@
                                 <div class="rag-word augment">AUGMENT</div>
                                 <div class="rag-arrow">→</div>
                                 <div class="rag-word generate">GENERATE</div>
+                            </div>
+                            <div class="rag-steps">
+                                <div class="rag-group">
+                                    <h4>Retrieval</h4>
+                                    <div class="rag-step">Embed query</div>
+                                    <div class="rag-step">Search database</div>
+                                </div>
+                                <div class="rag-group">
+                                    <h4>Augmentation</h4>
+                                    <div class="rag-step">Attach top documents</div>
+                                </div>
+                                <div class="rag-group">
+                                    <h4>Generation</h4>
+                                    <div class="rag-step">LLM crafts final answer</div>
+                                </div>
                             </div>
                         </div>
                         <div class="questions-section" data-delay="3000">

--- a/style.css
+++ b/style.css
@@ -1297,6 +1297,30 @@ h3 {
   overflow: hidden;
 }
 
+.vector-plot {
+  width: 100%;
+  height: 100%;
+}
+
+.axis {
+  stroke: var(--color-border);
+  stroke-width: 2;
+}
+
+.vector-line {
+  stroke: var(--color-primary);
+  stroke-width: 2;
+}
+
+.vector-point {
+  fill: var(--color-primary);
+}
+
+.vector-label {
+  font-size: var(--font-size-sm);
+  fill: var(--color-text);
+}
+
 .cluster {
   position: absolute;
   display: flex;
@@ -1446,24 +1470,24 @@ h3 {
 .line1 {
   top: 50%;
   left: 50%;
-  width: 150px;
-  transform: rotate(30deg);
+  width: 170px;
+  transform: rotate(-30deg);
   transform-origin: left center;
 }
 
 .line2 {
   top: 50%;
   left: 50%;
-  width: 120px;
-  transform: rotate(-20deg);
+  width: 160px;
+  transform: rotate(20deg);
   transform-origin: left center;
 }
 
 .line3 {
   top: 50%;
   left: 50%;
-  width: 100px;
-  transform: rotate(60deg);
+  width: 130px;
+  transform: rotate(35deg);
   transform-origin: left center;
 }
 
@@ -1642,6 +1666,13 @@ h3 {
   color: var(--color-text-secondary);
 }
 
+.chunk-feedback {
+  margin-top: var(--space-12);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  text-align: center;
+}
+
 .chunk-visualization {
   display: flex;
   justify-content: center;
@@ -1742,7 +1773,9 @@ h3 {
   flex-direction: column;
   align-items: center;
   gap: var(--space-24);
-  margin: var(--space-32) 0;
+  margin: var(--space-32) auto;
+  max-height: 60vh;
+  overflow-y: auto;
 }
 
 .hyde-step {
@@ -2127,6 +2160,28 @@ h3 {
 
 .rag-word.generate {
   animation-delay: 1s;
+}
+
+.rag-steps {
+  display: flex;
+  justify-content: center;
+  gap: var(--space-32);
+  margin-top: var(--space-24);
+}
+
+.rag-group {
+  text-align: center;
+}
+
+.rag-group h4 {
+  margin-bottom: var(--space-8);
+  color: var(--color-primary);
+  font-size: var(--font-size-md);
+}
+
+.rag-step {
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--space-4);
 }
 
 @keyframes wordPulse {


### PR DESCRIPTION
## Summary
- add 3-D vector plot for embedding space
- fix search arrows and add chunk slider feedback
- improve recap slide visuals and responsive HyDE layout
- group RAG steps in wrap-up slide
- update styles and slider script

## Testing
- `pip install numpy`
- `pip install sentence-transformers openai scikit-learn`
- `python3 rag_demo.py` *(fails: Can't load the model)*

------
https://chatgpt.com/codex/tasks/task_e_68549f7feae883318fbfa8248737177e